### PR TITLE
gitignore for backend dir

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml


### PR DESCRIPTION
Added .gitignore for backend dir. @orby-tech has advised me to keep pnpm-lock.yaml (since I use pnpm) ignored to avoid confusion 