### PR TITLE
Убрал NodeJS типы из общего тс-конфига, поправил тип на setTimeout

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -13,7 +13,7 @@ import {useRoute, useRouter} from 'vue-router'
 import DatalistInput from '@/components/common/input/DatalistInput.vue'
 import {BASE_URL} from '@/constants/url'
 
-let lasyLoadTimeout: NodeJS.Timeout | null = null
+let lasyLoadTimeout: ReturnType<typeof setTimeout> | undefined
 
 const locationStore = useLocationStore()
 locationStore.loadCountries()

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,10 +9,7 @@
     "./../common/**/*"
   ],
   "references": [
-    {
-      "path": "./tsconfig.node.json"
-    },
-    {
+        {
       "path": "./tsconfig.app.json"
     },
     {


### PR DESCRIPTION
Референс на `tsconfig.node.json` выдавал странную ошибку об отсутствии .d.ts файлов у импортов, а также делал нодовские глобальные якобы доступны и оверрайдил браузерные.
Также подправил указанный тип для `lasyLoadTimeout`