### PR TITLE
vue-i18n .d.ts fix

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,6 +17,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@common/*": ["./../common/*"]
-    }
+    }, 
+    "resolvePackageJsonExports": false, 
+    "moduleResolution": "bundler"
   }
 }


### PR DESCRIPTION
vue-i18n не обновил экспорты в package.json из-за чего ts 5.0 не подцепляет их .d.ts - потому приходится пока отключить `resolvePackageJsonExports` , это достаточно свежая проблема. У либы в репо нашел 2 issue на эту тему intlify/vue-i18n-next#1391 intlify/vue-i18n-next#1327

`moduleResolution` - это все к той же теме, это рекомендация от [Эвана](https://twitter.com/youyuxi/status/1636551895002255362?lang=en)